### PR TITLE
Setup per worker toggle for recording status

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,9 @@ As you noticed you can set expiration time for jobs globally by expiration optio
 
 ### Disabling recording of the initial :queued status and metadata
 By default, the client middleware records the initial metadata at job-creation.
-If this is not desired for all workers, it can be conditionally enabled
-by setting the `record_initial_status?` method on the worker's eigenclass:
+However, this functionality is disabled when using `Sidekiq::Batch`.
+For non-batch jobs, it can be conditionally enabled or disabled
+by setting the `record_initial_status?` method on the worker's singleton class:
 
 ``` ruby
 class MyVerboseJob

--- a/README.md
+++ b/README.md
@@ -91,6 +91,24 @@ As you noticed you can set expiration time for jobs globally by expiration optio
 + It is advised to set this expiration time greater than time required for completion of the job.
 + Default expiration time is 30 minutes.
 
+### Disabling recording of the initial :queued status and metadata
+By default, the client middleware records the initial metadata at job-creation.
+If this is not desired for all workers, it can be conditionally enabled
+by setting the `record_initial_status?` method on the worker's eigenclass:
+
+``` ruby
+class MyVerboseJob
+  def self.record_initial_status?
+    true
+  end
+end
+class MyQuietJob
+  def self.record_initial_status?
+    false
+  end
+end
+```
+
 ### Retrieving status
 
 Query for job status any time later:

--- a/lib/sidekiq-status/client_middleware.rb
+++ b/lib/sidekiq-status/client_middleware.rb
@@ -39,11 +39,16 @@ module Sidekiq::Status
     end
 
     def record_initial_status?(klass)
-      klass = Object.const_get(klass) if klass.is_a?(String)
+      return false if Thread.current[:sidekiq_batch]
+      klass = lookup_class(klass) if klass.is_a?(String)
       return true unless klass.respond_to?(:record_initial_status?)
       klass.record_initial_status?
+    end
+
+    def lookup_class(name)
+      Object.const_get(name)
     rescue NameError
-      true
+      nil
     end
   end
 end

--- a/lib/sidekiq-status/client_middleware.rb
+++ b/lib/sidekiq-status/client_middleware.rb
@@ -38,9 +38,12 @@ module Sidekiq::Status
       return msg['args'].to_a.empty? ? nil : msg['args'].to_json
     end
 
-    def record_initial_status?(worker_class)
-      return true unless worker_class.respond_to?(:record_initial_status?)
-      worker_class.record_initial_status?
+    def record_initial_status?(klass)
+      klass = Object.const_get(klass) if klass.is_a?(String)
+      return true unless klass.respond_to?(:record_initial_status?)
+      klass.record_initial_status?
+    rescue NameError
+      true
     end
   end
 end

--- a/lib/sidekiq-status/version.rb
+++ b/lib/sidekiq-status/version.rb
@@ -1,5 +1,5 @@
 module Sidekiq
   module Status
-    VERSION = '0.7.0'
+    VERSION = '0.8.0'
   end
 end

--- a/spec/lib/sidekiq-status/client_middleware_spec.rb
+++ b/spec/lib/sidekiq-status/client_middleware_spec.rb
@@ -38,6 +38,22 @@ describe Sidekiq::Status::ClientMiddleware do
         Sidekiq::Status::ClientMiddleware.new.call(StubJob, {'jid' => SecureRandom.hex}, :queued) do end
       end
     end
+
+    context "when worker_class.record_initial_status? is true" do
+      it 'still records the initial metadata' do
+        jid = VerboseJob.perform_async(:foo => 'bar')
+        expect(Sidekiq::Status.queued?(jid)).to be_truthy
+        expect(Sidekiq::Status.get_all(jid)).not_to be_empty
+      end
+    end
+
+    context "when worker_class.record_initial_status? is false" do
+      it 'does not record the initial metadata' do
+        jid = QuietJob.perform_async(:foo => 'bar')
+        expect(Sidekiq::Status.queued?(jid)).to be_falsey
+        expect(Sidekiq::Status.get_all(jid)).to be_empty
+      end
+    end
   end
 
   describe ":expiration parameter" do

--- a/spec/lib/sidekiq-status/client_middleware_spec.rb
+++ b/spec/lib/sidekiq-status/client_middleware_spec.rb
@@ -39,17 +39,44 @@ describe Sidekiq::Status::ClientMiddleware do
       end
     end
 
+    shared_context "using_sidekiq_batch" do
+      before { Thread.current[:sidekiq_batch] = Object.new }
+      after  { Thread.current[:sidekiq_batch] = nil }
+    end
+
+    context "when using Sidekiq::Batch" do
+      include_context "using_sidekiq_batch"
+
+      let(:jid) { StubJob.perform_async(:foo => 'bar') }
+
+      it 'does not record the initial metadata' do
+        expect(Sidekiq::Status.queued?(jid)).to be_falsey
+        expect(Sidekiq::Status.get_all(jid)).to be_empty
+      end
+    end
+
     context "when worker_class.record_initial_status? is true" do
+      let(:jid) { VerboseJob.perform_async(:foo => 'bar') }
+
       it 'still records the initial metadata' do
-        jid = VerboseJob.perform_async(:foo => 'bar')
         expect(Sidekiq::Status.queued?(jid)).to be_truthy
         expect(Sidekiq::Status.get_all(jid)).not_to be_empty
+      end
+
+      context "when using Sidekiq::Batch" do
+        include_context "using_sidekiq_batch"
+
+        it 'does not record the initial metadata' do
+          expect(Sidekiq::Status.queued?(jid)).to be_falsey
+          expect(Sidekiq::Status.get_all(jid)).to be_empty
+        end
       end
     end
 
     context "when worker_class.record_initial_status? is false" do
+      let(:jid) { QuietJob.perform_async(:foo => 'bar') }
+
       it 'does not record the initial metadata' do
-        jid = QuietJob.perform_async(:foo => 'bar')
         expect(Sidekiq::Status.queued?(jid)).to be_falsey
         expect(Sidekiq::Status.get_all(jid)).to be_empty
       end

--- a/spec/support/test_jobs.rb
+++ b/spec/support/test_jobs.rb
@@ -79,3 +79,15 @@ class RetriedJob < StubJob
     end
   end
 end
+
+class VerboseJob < StubJob
+  def self.record_initial_status?
+    true
+  end
+end
+
+class QuietJob < StubJob
+  def self.record_initial_status?
+    false
+  end
+end


### PR DESCRIPTION
@jlovell @avantcredit/platform-engineering 
`Sidekiq::Batch` creates all of its jobs atomically in one push to redis
however, the client middleware for `Sidekiq::Status` initializes itself one-by-one
this causes batches to take O(n) roundtrips to redis to setup
as such, batches above a certain size timeout and cannot be created

this PR allow individual workers to conditionally enable/disable recording of initial status metadata 

[view diff with no whitespace changes](1/files?w=1)